### PR TITLE
Fix JENA input parsing by reverting min/max weight change

### DIFF
--- a/src/input/JENAInput.cpp
+++ b/src/input/JENAInput.cpp
@@ -62,19 +62,11 @@ namespace yskInput{
 					else { //Weighted edges
 						weight = atof(tokens[j].c_str());
 						//Out of bounds values are assumed to be infinity
-// 						if (weight >= 1e+20) {
-// 							edgeType = PERMANENT;
-// 							weight = std::numeric_limits<double>::infinity();
-// 						}
-// 						else if (weight <= -1e+20) {
-// 							edgeType = FORBIDDEN;
-// 							weight = -std::numeric_limits<double>::infinity();
-// 						}
-						if (weight >= std::numeric_limits<double>::max()) {
+						if (weight >= 1e+20) {
 							edgeType = PERMANENT;
 							weight = std::numeric_limits<double>::infinity();
 						}
-						else if (weight <= std::numeric_limits<double>::min()) {
+						else if (weight <= -1e+20) {
 							edgeType = FORBIDDEN;
 							weight = -std::numeric_limits<double>::infinity();
 						}


### PR DESCRIPTION
Reverts the change to JENA input parsing where std::numeric_limits<double>::min() was used as the cutoff value for an edge to be forbidden, however in C++, this is defined as the minimum positive double value ~2.22507e-308, so all edges with weights less than or equal to 0 were marked forbidden. This could also be solved by using std::numeric_limits<double>::lowest() ~= -1.79769e+308, but I feel like the parsing may misbehave with values so close to the limits.