### PR TITLE
Fix heuristic calculation crash on verbosity >= 1

### DIFF
--- a/src/EdgeHeap.cpp
+++ b/src/EdgeHeap.cpp
@@ -37,7 +37,7 @@ void EdgeHeap::initInducedCosts() {
   
   // compute array: edge -> icf/icp
   for (NodeId u = 0; u < graph.numNodes(); u++) {
-    if (verbosity >= 1)
+    if (verbosity >= 1 && graph.numEdges() > 0)
       std::cout<<"Completed "<<(((2*graph.numNodes()-u)*(u+1)/2)*100/graph.numEdges())<<"%\r"<<std::flush;
     for (NodeId v = u + 1; v < graph.numNodes(); v++) {
       // iterate over all edges uv


### PR DESCRIPTION
When running heuristic mode on verbosity >= 1, the status update could result in a division by zero, if the graph had no edges, this is just a quick check to prevent the status update in that case.